### PR TITLE
Add content type to the curl command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 4) $ bin/elasticsearch     
 
 ### Insert data into elasticsearch
-     $ curl -XPOST localhost:9200/test/tweet   -d '{"name":"Satendra", "job":"consultant" , "location":"India", "age":28}'
-     $ curl -XPOST localhost:9200/test/tweet   -d '{"name":"Rohit", "job":"consultant" , "location":"India", "age":22}'
-     $ curl -XPOST localhost:9200/test/tweet   -d '{"name":"Mohit", "job":"consultant" , "location":"India", "age":25}'
+     $ curl -H "Content-Type:application/json" -XPOST localhost:9200/test/tweet   -d '{"name":"Satendra", "job":"consultant" , "location":"India", "age":28}'
+     $ curl -H "Content-Type:application/json" -XPOST localhost:9200/test/tweet   -d '{"name":"Rohit", "job":"consultant" , "location":"India", "age":22}'
+     $ curl -H "Content-Type:application/json" -XPOST localhost:9200/test/tweet   -d '{"name":"Mohit", "job":"consultant" , "location":"India", "age":25}'
  
 
 ### Run project 


### PR DESCRIPTION
When performing curl with post, new versions of elasticsearch requires you to have the context type in the call. Added the content type to the readme instructions.  